### PR TITLE
fix deprecation warning in Rails 3

### DIFF
--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -17,7 +17,7 @@ module Choices::Rails
     root = self.respond_to?(:root) ? self.root : Rails.root
     file = root + 'config' + name
     
-    settings = Choices.load_settings(file, RAILS_ENV)
+    settings = Choices.load_settings(file, Rails.env)
     @choices.update settings
     
     settings.each do |key, value|


### PR DESCRIPTION
This gem is fantastic. This commit gets rid of a deprecation warning about the RAILS_ENV constant. Thanks!
