### PR TITLE
Delegate boolean accessors to choices (even if they're undefined)

### DIFF
--- a/choices.gemspec
+++ b/choices.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'choices'
-  gem.version = '0.2.0'
-  gem.date    = Date.today.to_s
+  gem.version = '0.2.1'
+  gem.date    = Time.now.strftime('%Y-%m-%d')
 
   gem.add_dependency 'hashie', '>= 0.4.0'
   # gem.add_development_dependency 'rspec', '~> 1.2.9'

--- a/choices.gemspec
+++ b/choices.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'http://github.com/mislav/choices'
 
   gem.rubyforge_project = nil
-  gem.has_rdoc = false
 
   gem.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   # gem.files &= `git ls-files -z`.split("\0")

--- a/choices.gemspec
+++ b/choices.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'choices'
-  gem.version = '0.2.2'
+  gem.version = '0.2.3'
   gem.date    = Time.now.strftime('%Y-%m-%d')
 
   gem.add_dependency 'hashie', '>= 0.4.0'

--- a/choices.gemspec
+++ b/choices.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'choices'
-  gem.version = '0.2.3'
+  gem.version = '0.2.4'
   gem.date    = Time.now.strftime('%Y-%m-%d')
 
   gem.add_dependency 'hashie', '>= 0.4.0'

--- a/choices.gemspec
+++ b/choices.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'choices'
-  gem.version = '0.2.1'
+  gem.version = '0.2.2'
   gem.date    = Time.now.strftime('%Y-%m-%d')
 
   gem.add_dependency 'hashie', '>= 0.4.0'

--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -16,7 +16,7 @@ module Choices
   
   def load_settings_hash(filename, env)
     yaml_content = ERB.new(IO.read(filename)).result
-    YAML::load(yaml_content)[env]
+    yaml_load(yaml_content)[env]
   end
   
   def with_local_settings(filename, env, suffix)
@@ -24,6 +24,19 @@ module Choices
     if File.exists? local_filename
       hash = load_settings_hash(local_filename, env)
       yield hash if hash
+    end
+  end
+  
+  def yaml_load(content)
+    if defined? YAML::ENGINE
+      # avoid using broken Psych in 1.9.2
+      old_yamler = YAML::ENGINE.yamler
+      YAML::ENGINE.yamler = 'syck'
+    end
+    begin
+      YAML::load(content)
+    ensure
+      YAML::ENGINE.yamler = old_yamler if defined? YAML::ENGINE
     end
   end
 end

--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -17,7 +17,7 @@ module Choices::Rails
     root = self.respond_to?(:root) ? self.root : Rails.root
     file = root + 'config' + name
     
-    settings = Choices.load_settings(file, RAILS_ENV)
+    settings = Choices.load_settings(file, Rails.respond_to?(:env) ? Rails.env : RAILS_ENV)
     @choices.update settings
     
     settings.each do |key, value|

--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -29,6 +29,10 @@ module Choices::Rails
     super or method.to_s =~ /=$/ or (method.to_s =~ /\?$/ and @choices.key?($`))
   end
 
+  def[](key)
+    @choices[key] || super.send(key)
+  end
+
   private
 
     def method_missing(method, *args, &block)

--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -24,6 +24,22 @@ module Choices::Rails
       self.send("#{key}=", value)
     end
   end
+
+  def respond_to?(method)
+    super or method.to_s =~ /=$/ or (method.to_s =~ /\?$/ and @choices.key?($`))
+  end
+
+  private
+
+    def method_missing(method, *args, &block)
+      if method.to_s =~ /=$/ or method.to_s =~ /\?$/
+        @choices.send(method, *args)
+      elsif @choices.key?(method)
+        @choices[method]
+      else
+        super
+      end
+    end
 end
 
 if defined? Rails::Application::Configuration
@@ -31,22 +47,5 @@ if defined? Rails::Application::Configuration
 elsif defined? Rails::Configuration
   Rails::Configuration.class_eval do
     include Choices::Rails
-    include Module.new {
-      def respond_to?(method)
-        super or method.to_s =~ /=$/ or (method.to_s =~ /\?$/ and @choices.key?($`))
-      end
-      
-      private
-      
-      def method_missing(method, *args, &block)
-        if method.to_s =~ /=$/ or (method.to_s =~ /\?$/ and @choices.key?($`))
-          @choices.send(method, *args)
-        elsif @choices.key?(method)
-          @choices[method]
-        else
-          super
-        end
-      end
-    }
   end
 end


### PR DESCRIPTION
With a config like this:

```
defaults: &defaults
  strict_choices: true

 development:
   <<: *defaults
```

This allows you to do:

```
Rails.configuration.strict_choices?
#=> true

Rails.configuration.wtf?
#=> false

Rails.configuration.wtf
#=> undefined method `wtf' for #<Rails::Application::Configuration:0x103213ff0>
```
