### PR TITLE
Don't overwrite existing deeply nested config values

### DIFF
--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -21,6 +21,12 @@ module Choices::Rails
     @choices.update settings
     
     settings.each do |key, value|
+      old_value = self.respond_to?(key) ? self.send(key) : nil
+
+      if old_value && old_value.is_a?(Hash) && value.is_a?(Hash)
+        value = Hashie::Mash.new(old_value).update value
+      end
+
       self.send("#{key}=", value)
     end
   end


### PR DESCRIPTION
It would be nice if existing deeply nested config values woud get merged/updated by values in the `.yml` file instead of being overwritten. This pull request tries to add this behaviour.

Oh, and by the way, it would be really great to have some specs for this gem. It would probably make developers feel a lot safer, since it deals with a pretty crucial part of the app. I could find some free time to help out with this if you want.  Let me know.

Thanks,
Cezar.
