### PR TITLE
Remove syck deprecation warning in ruby-2.0.0

### DIFF
--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -28,7 +28,7 @@ module Choices
   end
   
   def yaml_load(content)
-    if defined? YAML::ENGINE
+    if defined?(YAML::ENGINE) && defined?(Syck)
       # avoid using broken Psych in 1.9.2
       old_yamler = YAML::ENGINE.yamler
       YAML::ENGINE.yamler = 'syck'
@@ -36,7 +36,7 @@ module Choices
     begin
       YAML::load(content)
     ensure
-      YAML::ENGINE.yamler = old_yamler if defined? YAML::ENGINE
+      YAML::ENGINE.yamler = old_yamler if defined?(YAML::ENGINE) && defined?(Syck)
     end
   end
 end


### PR DESCRIPTION
This pull request fixes mislav/choices#8 by making sure that `Syck` is defined (it’s not in ruby-2.0.0) before using it as the YAML engine.
