### PR TITLE
Include license in gemspec

### DIFF
--- a/choices.gemspec
+++ b/choices.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
   gem.authors  = ['Mislav Marohnić']
   gem.email    = 'mislav.marohnic@gmail.com'
   gem.homepage = 'https://github.com/mislav/choices'
+  gem.license  = "MIT"
 
   gem.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
 end


### PR DESCRIPTION
This helps automated tools and users find the license.

I'm suggesting MIT as it seems to be your license of choice.
