### PR TITLE
Environment error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require 'bundler'
+require 'rake/testtask'
+require 'minitest'
 Bundler::GemHelper.install_tasks
+
+Rake::TestTask.new do |t|
+end
+
+desc 'Run test suite'
+task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'bundler'
 require 'rake/testtask'
-require 'minitest'
+
 Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |t|

--- a/choices.gemspec
+++ b/choices.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.version = '0.3.2'
 
   gem.add_dependency 'hashie', '>= 0.4.0'
-  # gem.add_development_dependency 'rspec', '~> 1.2.9'
+  gem.add_development_dependency 'minitest', '~> 5.0.6'
 
   gem.summary = "Easy settings for your app"
   # gem.description = "Longer description."
@@ -16,4 +16,5 @@ Gem::Specification.new do |gem|
   gem.license  = 'MIT'
 
   gem.files = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*', 'README*', '*LICENSE*']
+  gem.test_files = Dir.glob('test/test_*.rb')
 end

--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -16,7 +16,11 @@ module Choices
   
   def load_settings_hash(filename, env)
     yaml_content = ERB.new(IO.read(filename)).result
-    yaml_load(yaml_content)[env]
+    choices = yaml_load(yaml_content)
+    unless choices.has_key? env
+      raise EnvironmentMissingError, "You are missing environment (#{env}) in #{filename}."
+    end
+    choices[env]
   end
   
   def with_local_settings(filename, env, suffix)
@@ -39,6 +43,8 @@ module Choices
       YAML::ENGINE.yamler = old_yamler if defined?(YAML::ENGINE) && defined?(Syck)
     end
   end
+
+  class EnvironmentMissingError < StandardError; end;
 end
 
 if defined? Rails

--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -1,5 +1,6 @@
 require 'hashie/mash'
 require 'erb'
+require 'yaml'
 
 module Choices
   extend self

--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -5,28 +5,27 @@ module Choices
   extend self
   
   def load_settings(filename, env)
-    mash = Hashie::Mash.new(load_settings_hash(filename, env))
+    mash = Hashie::Mash.new(load_settings_hash(filename))
     
-    with_local_settings(filename, env, '.local') do |local|
+    with_local_settings(filename, '.local') do |local|
       mash.update local
     end
     
-    return mash
-  end
-  
-  def load_settings_hash(filename, env)
-    yaml_content = ERB.new(IO.read(filename)).result
-    choices = yaml_load(yaml_content)
-    unless choices.has_key? env
+    unless mash.has_key? env
       raise EnvironmentMissingError, "You are missing environment (#{env}) in #{filename}."
     end
-    choices[env]
+    return mash[env]
+  end
+
+  def load_settings_hash(filename)
+    yaml_content = ERB.new(IO.read(filename)).result
+    yaml_load(yaml_content)
   end
   
-  def with_local_settings(filename, env, suffix)
+  def with_local_settings(filename, suffix)
     local_filename = filename.sub(/(\.\w+)?$/, "#{suffix}\\1")
     if File.exists? local_filename
-      hash = load_settings_hash(local_filename, env)
+      hash = load_settings_hash(local_filename)
       yield hash if hash
     end
   end

--- a/test/settings/with_local.local.yml
+++ b/test/settings/with_local.local.yml
@@ -1,0 +1,5 @@
+development:
+  name: 'Development'
+
+production:
+  name: 'Production local'

--- a/test/settings/with_local.yml
+++ b/test/settings/with_local.yml
@@ -1,0 +1,6 @@
+defaults: &defaults
+  name: 'Defaults'
+
+production:
+  <<: *defaults
+

--- a/test/settings/without_local.yml
+++ b/test/settings/without_local.yml
@@ -1,0 +1,13 @@
+defaults: &defaults
+  name: 'Defaults'
+
+development:
+  name: 'Development'
+
+production:
+  <<: *defaults
+  name: 'Production'
+
+test:
+  name: 'Test'
+

--- a/test/test_load_settings.rb
+++ b/test/test_load_settings.rb
@@ -21,5 +21,11 @@ describe Choices do
       Choices.load_settings(@with_local, 'development').name.must_equal 'Development'
       Choices.load_settings(@with_local, 'production').name.must_equal 'Production local'
     end
+
+    it 'should raise an exception if the environment does not exist' do
+      lambda do
+        Choices.load_settings(@with_local, 'inexistant')
+      end.must_raise Choices::EnvironmentMissingError
+    end
   end
 end

--- a/test/test_load_settings.rb
+++ b/test/test_load_settings.rb
@@ -1,0 +1,25 @@
+gem 'minitest'
+require 'minitest/autorun'
+require 'choices'
+require 'pathname'
+
+describe Choices do
+  before do
+    path = Pathname.new(__FILE__)
+    @without_local = path + '../settings/without_local.yml'
+    @with_local = path + '../settings/with_local.yml'
+  end
+
+  describe 'when loading a settings file' do
+    it 'should return a mash for the specified environment' do
+      Choices.load_settings(@without_local, 'defaults').name.must_equal 'Defaults'
+      Choices.load_settings(@without_local, 'production').name.must_equal 'Production'
+    end
+
+    it 'should load the local settings' do
+      Choices.load_settings(@with_local, 'defaults').name.must_equal 'Defaults'
+      Choices.load_settings(@with_local, 'development').name.must_equal 'Development'
+      Choices.load_settings(@with_local, 'production').name.must_equal 'Production local'
+    end
+  end
+end


### PR DESCRIPTION
Currently, choices silently parse the YAML file even if the current environment is not specified in the file.

In a test environment, it starts by calling schema.db from the development environment and then switch to the test one. The stack trace is not obvious and can lead to confusion. Raising an error if the environment is unspecified fixes that.
