### PR TITLE
Choices Within Engines

### DIFF
--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -39,8 +39,8 @@ module Choices::Rails
   end
 end
 
-if defined? Rails::Application::Configuration
-  Rails::Application::Configuration.send(:include, Choices::Rails)
+if defined? Rails::Engine::Configuration
+  Rails::Engine::Configuration.send(:include, Choices::Rails)
 elsif defined? Rails::Configuration
   Rails::Configuration.class_eval do
     include Choices::Rails


### PR DESCRIPTION
Fixes #12

`Rails::Application::Configuration` is a child of `Rails::Engine::Configuration`.
`engines/foo/lib/foo/engine.rb` uses `Rails::Engine::Configuration`.
Send `Choices::Rails` to `Rails::Engine::Configuration`, so its included for a
main app and an engine app.
