### PR TITLE
Add support for variables substituion similar to I18n.

### DIFF
--- a/test/settings/with_local.local.yml
+++ b/test/settings/with_local.local.yml
@@ -3,3 +3,5 @@ development:
 
 production:
   name: 'Production local'
+  mailer:
+    host: 'production.local'

--- a/test/settings/with_local.yml
+++ b/test/settings/with_local.yml
@@ -1,6 +1,11 @@
 defaults: &defaults
   name: 'Defaults'
+  mailer:
+   host: 'localhost'
+  email: '%{name}@%{mailer.host}'
 
 production:
   <<: *defaults
+  mailer:
+    host: 'production.com'
 

--- a/test/settings/without_local.yml
+++ b/test/settings/without_local.yml
@@ -1,5 +1,8 @@
 defaults: &defaults
   name: 'Defaults'
+  mailer:
+    host: 'localhost'
+  email: '%{name}@%{mailer.host}'
 
 development:
   name: 'Development'
@@ -7,7 +10,13 @@ development:
 production:
   <<: *defaults
   name: 'Production'
+  mailer:
+    host: 'production.com'
 
 test:
+  <<: *defaults
   name: 'Test'
 
+index_error:
+  name: 'Defaults'
+  email: '%{nonexistent.key}'

--- a/test/test_load_settings.rb
+++ b/test/test_load_settings.rb
@@ -22,6 +22,26 @@ describe Choices do
       Choices.load_settings(@with_local, 'production').name.must_equal 'Production local'
     end
 
+    describe 'variables substitution' do
+      it 'should substitute variables' do
+        Choices.load_settings(@without_local, 'defaults').email.must_equal 'Defaults@localhost'
+        Choices.load_settings(@without_local, 'test').email.must_equal 'Test@localhost'
+        Choices.load_settings(@without_local, 'production').email.must_equal 'Production@production.com'
+      end
+
+      it 'should substitute from local settings too' do
+        Choices.load_settings(@with_local, 'defaults').email.must_equal 'Defaults@localhost'
+        Choices.load_settings(@with_local, 'production').email.must_equal 'Production local@production.local'
+      end
+
+      it 'should raise an exception when substitution key does not exist' do
+        error = lambda {
+          Choices.load_settings(@without_local, 'index_error')
+        }.must_raise(IndexError)
+        error.message.must_equal %{Missing key for "%{nonexistent.key}" in `#{@without_local}'}
+      end
+    end
+
     it 'should raise an exception if the environment does not exist' do
       error = lambda {
         Choices.load_settings(@with_local, 'nonexistent')


### PR DESCRIPTION
Hey!
I thought it would be nice to have variable substitution, just like `I18n` does it, since `YAML` does not allow string concatenation and **partial** existing parameter substitution.
So, assuming we have the following YAML-file:

``` yaml
defaults: &defaults
  name: 'Defaults'
  mailer:
   host: 'localhost'
  email: '%{name}@%{mailer.host}'
```

`email` will be equal to `Defaults@localost`. 
Local settings and nested keys are supported too, see tests for more.
